### PR TITLE
fix: fixed InvokeFunctionReference nil error

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -147,7 +147,7 @@ function HandleKey(keymap, controlmap, name, key, handler, usesAlt)
         if handler then
             if type(handler) == "table" then
                 local payload = msgpack.pack({keymap, name, key, controlmap, usesAlt})
-                InvokeFunctionReference(handler.__cfx_functionReference, payload, payload:len(), 0)
+                Citizen.InvokeFunctionReference(handler.__cfx_functionReference, payload, payload:len(), 0)
             elseif type(handler) == 'string' then
                 TriggerServerEvent(handler, keymap, name, key, controlmap, usesAlt)
             else


### PR DESCRIPTION
While this resource worked correctly for me at first, following one of the recent FiveM updates the callback passed to `alertbox:message` began to throw errors due to `InvokeFunctionReference` being `nil`. Replacing it with `Citizen.InvokeFunctionReference` seems to work fine